### PR TITLE
downsample before sending to client removed goroutines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,20 @@
 module waggle
 
-go 1.23
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
-	github.com/disintegration/imaging v1.6.2 // indirect
-	github.com/gorilla/mux v1.8.1 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/disintegration/imaging v1.6.2
+	github.com/gorilla/mux v1.8.1
+	github.com/gorilla/websocket v1.5.3
+	github.com/rs/zerolog v1.33.0
+)
+
+require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
-	github.com/rs/zerolog v1.33.0 // indirect
 	golang.org/x/image v0.25.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func batchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := RobotData{
-		SaveReplay: true,
+		// 	SaveReplay: true, //default to true
 	}
 
 	err = json.Unmarshal(body, &data)
@@ -69,12 +69,12 @@ func batchHandler(w http.ResponseWriter, r *http.Request) {
 		log.Println("Body:", string(body))
 		return
 	}
+	if data.SaveReplay {
+		replay_manger.write_update(data)
+	}
 	addDataToBuffer(data)
 	if readyToSend {
 		broadcastMessage()
-	}
-	if data.SaveReplay {
-		go replay_manger.write_update(data)
 	}
 }
 


### PR DESCRIPTION
- store raw replay images
- don't send non-displayed replays to client